### PR TITLE
Switch CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: "nix test"
+on:
+    pull_request:
+    push:
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2.3.4
+        - uses: cachix/install-nix-action@v12
+        - run:  nix-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: nix


### PR DESCRIPTION
GitHub Actions doesn't have a finite one-off pool of credits like Travis unfortunately does now. :(