### PR TITLE
Fix GitHub actions build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,11 @@
 { pkgs ? import ./nix/nixpkgs.nix { config = import ./nix/config.nix; } }:
 
-builtins.deepSeq
-  (builtins.readFile ./package.yaml)
-  (pkgs.haskellPackages.callCabal2nix "aoc" (builtins.fetchGit ./.) {})
+let
+  src = builtins.filterSource (path: type:
+    (type != "directory" || baseNameOf path != ".dist-newstyle") &&
+    (type != "symlink"   || baseNameOf path != "result")) ./.;
+
+in
+  builtins.deepSeq
+    (builtins.readFile ./package.yaml)
+    (pkgs.haskellPackages.callCabal2nix "aoc" src {})


### PR DESCRIPTION
Uses `filterSource` instead of `fetchGit` on `./.`. Although the `fetchGit` workaround was beautiful, it fails on GitHub Actions as it can't work on a shallow clone of itself.